### PR TITLE
Add `_opam` to .gitignore for local switch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Book specific
 playground
+
+# Opam switch
+_opam/


### PR DESCRIPTION
As of OPAM 2.0, support is included [local switches](https://opam.ocaml.org/blog/opam-local-switches/) so that projects can each have their own switch. This pull request adds `_opam` to `.gitignore` so that a local switch can be used and not accidentally committed.