### PR TITLE
Remove semi-colon from last print_endline

### DIFF
--- a/src/chapters/basics/printing.md
+++ b/src/chapters/basics/printing.md
@@ -78,7 +78,7 @@ evaluates `e2`. So we could rewrite the above code as:
 ```{code-cell} ocaml
 print_endline "Camels";
 print_endline "are";
-print_endline "bae";
+print_endline "bae"
 ```
 
 That is more idiomatic OCaml code, and it also looks more natural to imperative


### PR DESCRIPTION
The warning infobox in 2.6.2 states _"There is no semicolon after the final print_endline in that example."_  just below the example but there is a semicolon after the final print_endline.