### PR TITLE
Removed extra semicolon in printing.md

### DIFF
--- a/src/chapters/basics/printing.md
+++ b/src/chapters/basics/printing.md
@@ -78,7 +78,7 @@ evaluates `e2`. So we could rewrite the above code as:
 ```{code-cell} ocaml
 print_endline "Camels";
 print_endline "are";
-print_endline "bae";
+print_endline "bae"
 ```
 
 That is more idiomatic OCaml code, and it also looks more natural to imperative


### PR DESCRIPTION
There is a semicolon at the end of the last print_endline in the "Semicolon" section, even though the warning says that the example does not end with a semicolon.