### PR TITLE
Dictionary module type -> Map module type

### DIFF
--- a/src/chapters/modules/exercises.md
+++ b/src/chapters/modules/exercises.md
@@ -86,9 +86,9 @@ it has never had any elements dequeued. Explain in your own words why
 to the queue takes time that is linear in $n$.
 
 <!--------------------------------------------------------------------------->
-{{ ex3 | replace("%%NAME%%", "binary search tree dictionary")}}
+{{ ex3 | replace("%%NAME%%", "binary search tree map")}}
 
-Write a module `BstDict` that implements the `Dictionary` module type using the
+Write a module `BstMap` that implements the `Map` module type using the
 a binary search tree type.
 
 <!--------------------------------------------------------------------------->


### PR DESCRIPTION
It seems to me that the wording of the exercise was copied without change from one of the previous iterations of the course. There was a [chapter called Dictionaries](https://www.cs.cornell.edu/courses/cs3110/2021sp/textbook/modules/ex_dictionaries.html), and the module type was Dictionary. But in the present version of the book that chapter is called Maps and the module type, accordingly, is called Map.