### PR TITLE
fixed odoc markup for batchedqueue

### DIFF
--- a/src/chapters/modules/functional_data_structures.md
+++ b/src/chapters/modules/functional_data_structures.md
@@ -379,7 +379,7 @@ constant-time operation.
 
 ```{code-cell} ocaml
 module BatchedQueue : Queue = struct
-  (** [{o; i]} represents the queue [o @ List.rev i]. For example,
+  (** [{o; i}] represents the queue [o @ List.rev i]. For example,
       [{o = [1; 2]; i = [5; 4; 3]}] represents the queue [1, 2, 3, 4, 5],
       where [1] is the front element. To avoid ambiguity about emptiness,
       whenever only one of the lists is empty, it must be [i]. For example,


### PR DESCRIPTION
minor fix to odoc markup for BatchedQueue interface:
- `[{o; i]}` :arrow_right: `[{o; i}]`