### PR TITLE
fix: small codeblock formatting issue

### DIFF
--- a/src/chapters/basics/functions.md
+++ b/src/chapters/basics/functions.md
@@ -466,7 +466,7 @@ let x = e [in e']
 ```
 
 and that OCaml infers `x` has a type `t` that includes some type variables `'a`,
-'`b`, etc. Then we are permitted to instantiate those type variables. We can do
+`'b`, etc. Then we are permitted to instantiate those type variables. We can do
 that by applying the function to arguments that reveal what the type
 instantiations should be (as in `id 5`) or by a type annotation (as in
 `id_int'`), among other ways. But we have to be consistent with the


### PR DESCRIPTION
Just a small fix to move from '`b` to `'b` on the functions page.