### PR TITLE
Update Microsoft WSL install instructions link

### DIFF
--- a/src/chapters/preface/install.md
+++ b/src/chapters/preface/install.md
@@ -105,7 +105,7 @@ WSL][wsl]. Here are a few notes on Microsoft's instructions:
   checked. Now Ctrl+Shift+C will copy and Ctrl+Shift+V will paste into the
   terminal. Note that you have to include Shift as part of that keystroke.
 
-[wsl]: https://docs.microsoft.com/en-us/windows/wsl/install-win10
+[wsl]: https://docs.microsoft.com/en-us/windows/wsl/install-manual
 [rh-virt]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/virtualization_administration_guide/sect-virtualization-troubleshooting-enabling_intel_vt_and_amd_v_virtualization_hardware_extensions_in_bios
 
 When you've finished installing WSL, open the Ubuntu app.  You will be at


### PR DESCRIPTION
I've changed the link for WSL installation to https://docs.microsoft.com/en-us/windows/wsl/install-manual the manual installation instead of the quick install. A few reasons:
1. The notes on instructions in the textbook correspond to the manual install instructions. In the past, there was only the manual installation instructions, but then microsoft added a quick install, making it incongruous with the textbook notes on instructions.
2. The quick install seems to cause more trouble than it saves. I've seen the following problems:
(1) students pressing buttons or keys or exiting out midway through the process because it is one step that takes a long time
(2) students trying to use the quick install on a version of Windows that is too old 
(3) various bugs with the quick install that are difficult to fix/little documentation 

For those reasons, I think we should stick with the manual install