### PR TITLE
Make OCaml Platform installation clearer

### DIFF
--- a/src/chapters/preface/install.md
+++ b/src/chapters/preface/install.md
@@ -309,15 +309,11 @@ are already a power user of Emacs or Vim those are great, too.)
   any open terminals to let the new path settings take effect.
 
 - **For everyone:** In the extensions pane, search for and install the "OCaml Platform" extension.
-  Be careful to use the extension with exactly the right name. **Windows only:**
+  Be careful to use the extension with _exactly the right name_ - the correct extension will also have an icon of a camel on a black background, as opposed to a red or orange background. **Windows only:**
   make sure you install the extension with the button that says "Install on WSL:
   ...", not with a button that says only "Install". The latter will not
   work.
-  
-  The correct extension should look like this.
-  
-  ![OCaml Platform](https://i.imgur.com/khTNJIT.png)
-  
+   
 ```{warning}
 The extensions named simply "OCaml" or "OCaml and Reason IDE" are not the right ones. (They
 are both old and no longer maintained by their developers.)

--- a/src/chapters/preface/install.md
+++ b/src/chapters/preface/install.md
@@ -308,13 +308,20 @@ are already a power user of Emacs or Vim those are great, too.)
   "Shell Command: Install 'code' command in PATH" command. Run it. Then close
   any open terminals to let the new path settings take effect.
 
-- In the extensions pane, search for and install the "OCaml Platform" extension.
-  Be careful to use the extension with exactly the right name. The extensions
-  named simply "OCaml" or "OCaml and Reason IDE" are not the right ones. (They
-  are both old and no longer maintained by their developers.) **Windows only:**
+- **For everyone:** In the extensions pane, search for and install the "OCaml Platform" extension.
+  Be careful to use the extension with exactly the right name. **Windows only:**
   make sure you install the extension with the button that says "Install on WSL:
   ...", not with a button that says only "Install". The latter will not
   work.
+  
+  The correct extension should look like this.
+  
+  ![OCaml Platform](https://i.imgur.com/khTNJIT.png)
+  
+```{warning}
+The extensions named simply "OCaml" or "OCaml and Reason IDE" are not the right ones. (They
+are both old and no longer maintained by their developers.)
+``` 
 
 [vscode]: https://code.visualstudio.com/
 


### PR DESCRIPTION
From the 3110 slack: "Could we fix the textbook to make the OCaml Platform extension more obvious? As is, it's a bullet underneath the Mac instructions and lots of people have not seen to install it (the recent ed post and at least three people during my install clinic hours yesterday)"

I've proposed the following changes to the book which should make this clearer, and added an image to draw attention to this bullet point, as well as make the warning about the outdated extensions obvious.