### PR TITLE
Chapter 5 - Correct  Java version to 1.8

### DIFF
--- a/src/chapters/modules/functors.md
+++ b/src/chapters/modules/functors.md
@@ -768,4 +768,4 @@ functionality. And no subtyping relationships are necessarily involved.
 Moreover, the functor we wrote can be used to extend **any** set implementation
 with `of_list`, whereas class extension applies to just a **single** base class.
 There are ways of achieving something similar in Java with *mixins*, which were
-added in Java 1.5.
+added in Java 1.8.


### PR DESCRIPTION
Loving the OCaml book and the videos. They're the best learning resource I've come across in a long time!

Thanks for doing those @clarksmr.

I presume that Java's introduction of `default` methods is what's being referred to in [_5.9.4.2 Extending Multiple Modules_](https://bit.ly/FunXins):

 > "..._something similar in Java with mixins, which were added in Java 1.5_..."

[_Some purists would argue_](https://bit.ly/PuriXins) that Java Interface's `default` methods are technically not "_true_" mixins. I don't think the distinction matters in the context of this section.

The following supports that the `default` methods feature of Java's interfaces was introduced in Java SE 8:

* [_Brian Goetz, Java Language Architect at Oracle_](https://bit.ly/AlsoMixins)
* [_Mixins Wikipedia article_](https://bit.ly/SE8default)

Is the book's mention of "_Java 1.5_" a typo?