### PR TITLE
fix typo, define n in party optimization problem

### DIFF
--- a/src/chapters/ds/memoization.md
+++ b/src/chapters/ds/memoization.md
@@ -147,8 +147,9 @@ Each employee has an associated “fun value” and we want the set of invited
 employees to have a maximum total fun value. However, no employee is fun if his
 superior is invited, so we never invite two employees who are connected in the
 org chart. (The less fun name for this problem is the maximum weight independent
-set in a tree.) There are $2n$ possible invitation lists, so the naive algorithm
-that compares the fun of every invitation list takes exponential time.
+set in a tree.) For an org chart with $n$ employees, there are $2^{n}$ possible 
+invitation lists, so the naive algorithm that compares the fun of every valid 
+invitation list takes exponential time.
 
 We can use memoization to turn this into a linear-time algorithm. We start by
 defining a variant type to represent the employees. The int at each node is the


### PR DESCRIPTION
The text says that there are 2n possible invitation lists, but naively there are 2^n invitation lists, one for every subset of the employees.

The phrasing is also somewhat ambiguous--is O(n * 2^n) considered "exponential time"? since the validity check and fun value of each possible invitation list take O(n) time to compute.