### PR TITLE
Correct typo

### DIFF
--- a/src/chapters/basics/compiling.md
+++ b/src/chapters/basics/compiling.md
@@ -11,7 +11,7 @@ For example, you could use the following commands:
 
 ```console
 $ mkdir hello-world
-$ code hello-world
+$ cd hello-world
 ```
 
 ```{warning}


### PR DESCRIPTION
On line 14, `code hello-world` was changed to `cd hello-world`, as it appears to be a typo.