### PR TITLE
fix Memoized.party

### DIFF
--- a/src/chapters/ds/memoization.md
+++ b/src/chapters/ds/memoization.md
@@ -214,14 +214,14 @@ module Memoized = struct
   let rec party t : int * string list =
     match t with
     | Empty -> (0, [])
-    | Node (v, name, left, right, memo) -> (
+    | Node (_, name, left, right, memo) -> (
         match !memo with
         | Some result -> result
         | None ->
             let infun, innames = party_in t in
             let outfun, outnames = party_out t in
             let result =
-              if infun > outfun then (v + infun, name :: innames)
+              if infun > outfun then (infun, innames)
               else (outfun, outnames)
             in
             memo := Some result;
@@ -237,7 +237,7 @@ module Memoized = struct
   and party_out t =
     match t with
     | Empty -> (0, [])
-    | Node (v, _, l, r, _) ->
+    | Node (_, _, l, r, _) ->
         let lfun, lnames = party l and rfun, rnames = party r in
         (lfun + rfun, lnames @ rnames)
 end


### PR DESCRIPTION
fix https://github.com/cs3110/textbook/issues/37

Just think about the simplest situation, that is, there is only one node in the org chart. For example,

```ocaml
let t = Memoized.(Node (100, "Vincent", Empty, Empty, ref None))
```

Then in `party t`, obviously `party_in t` wins. Let's dive into `party_in t`. Obviously `party_out l` and `party_out r` both return `(0, [])`, so `party_in t` will return `(v + 0 + 0, name :: [] @ [])`, that is, `(100, ["Vincent"])`. Go back to `party t`

```ocaml
if infun > outfun then (v + infun, name :: innames)
else (outfun, outnames)
```

it will return `(200, ["Vincent", "Vincent"])`, which is obviously wrong.