### PR TITLE
Fix 5.4 ListStack pretty print example

### DIFF
--- a/src/chapters/modules/encapsulation.md
+++ b/src/chapters/modules/encapsulation.md
@@ -667,7 +667,7 @@ module ListStack : Stack = struct
     let pp_break fmt () = fprintf fmt "@," in
     fprintf fmt "@[<v 0>top of stack";
     if s <> [] then fprintf fmt "@,";
-    pp_print_list ~pp_sep:pp_break pp_val fmt (List.rev s);
+    pp_print_list ~pp_sep:pp_break pp_val fmt s;
     fprintf fmt "@,bottom of stack@]"
 end
 ```


### PR DESCRIPTION
  The head of the list representation is the top of the stack,
  so there is no need to reverse the list.

Instead of:
``` ocaml
(* copy from 5.4.3 *)
ListStack.(empty |> push 1 |> push 2)

- : int ListStack.t = top of stack
                      1
                      2
                      bottom of stack
```
it should be:
``` ocaml
- : int ListStack.t = top of stack
                      2
                      1
                      bottom of stack
```