### PR TITLE
Correct the dynamic semantics of type annotations

### DIFF
--- a/src/chapters/basics/expressions.md
+++ b/src/chapters/basics/expressions.md
@@ -601,8 +601,8 @@ a check that the expression really does have the given type.
 
 Note that the parentheses are required.
 
-**Dynamic semantics.** There is no run-time meaning for a type annotation.
-It goes away during compilation, because it indicates a compile-time check.
-There is no run-time conversion.
+**Dynamic semantics.** If `e` evaluates to `v`, then `(e : t)` evaluates to `v`.
+It gives the same result of `e` because a type annotation indicates a compile-time
+check and has no effects during run-time. There is no run-time conversion.
 
 **Static semantics.**  If `e` has type `t` then `(e : t)` has type `t`.


### PR DESCRIPTION
I want to thank you all for this excellent textbook. I am using this in my course now. However, I think the dynamic semantics of the type annotations is a bit off, and I hope this pull request can help improve the textbook from which I benefit greatly. Please consider this as my way of saying thanks.

The explanation is a bit off for two reasons: (1) there is still computation going on even if all annotations are removed, and (2) the dynamic semantics is a specification for the source language, not the target language, and type annotations are part of the syntax of the source language; the current wording would make sense only after specifying a target language without type annotations, but I believe we do not want to do that.