### PR TITLE
Correct function application order

### DIFF
--- a/src/chapters/data/exceptions.md
+++ b/src/chapters/data/exceptions.md
@@ -113,8 +113,9 @@ following code raises `A`:
 :tags: ["raises-exception"]
 let _ = raise A in raise B;;
 ```
-And with functions, the argument must be evaluated before the function. So the
-following code also raises `A`, in addition to producing some compiler warnings
+And with functions, OCaml does not officially specify the evaluation order of a function
+and its argument, but the current implementation evaluates the argument before the function.
+So the following code also raises `A`, in addition to producing some compiler warnings
 that the first expression will never actually be applied as a function to an
 argument:
 ```{code-cell} ocaml


### PR DESCRIPTION
OCaml intentionally does not specify the evaluation order of functions and their arguments. The current implementation uses the anti-texual order (at least in most cases). It is technically possible that it will one day adopt the textual order used by Standard ML. Relevant text in the manual: https://v2.ocaml.org/manual/expr.html#sss:expr-functions-application

The same code will raise the other exception in any languages using the textual order. For example, the following code will raise B in Standard ML:
```
exception A
exception B
val _ : int = (raise B) (raise A)
```

This PR attempts to restore correctness with minimum changes. Again, thanks for the textbook.