### PR TITLE
Add nb_merge_streams config to coalesce stderr

### DIFF
--- a/src/_config.yml
+++ b/src/_config.yml
@@ -15,6 +15,7 @@ sphinx:
     # All files from these paths will be included in the generated
     # HTML output, even if they are not linked from any page
     html_extra_path: ['assets']
+    nb_merge_streams: true
 
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html

--- a/src/chapters/data/lists.md
+++ b/src/chapters/data/lists.md
@@ -413,14 +413,6 @@ By presenting that warning to the programmer, the compiler is helping the
 programmer to defend against the possibility of `Match_failure` exceptions at
 runtime.
 
-```{note}
-Sorry about how the output from the cell above gets split into many lines in the
-HTML. That is currently an [open issue with JupyterBook][issue], the framework
-used to build this book.
-
-[issue]: https://github.com/executablebooks/jupyter-book/issues/973
-```
-
 Second, **unused branches:** the compiler checks to see whether any of the
 branches could never be matched against because one of the previous branches is
 guaranteed to succeed. For example, the function below will cause the compiler


### PR DESCRIPTION
Hello! This is a small fix for the issue discussed in https://cs3110.github.io/textbook/chapters/data/lists.html about cell output being split into multiple output blocks. The upstream issue was fixed: executablebooks/jupyter-book#973, executablebooks/MyST-NB#364.

**Before**

<img width="641" alt="Before HTML" src="https://user-images.githubusercontent.com/122629585/219987641-d5a0f390-af75-4630-a610-a3c36ae11c73.png">

**After**

<img width="626" alt="After HTML" src="https://user-images.githubusercontent.com/122629585/219987767-27f724fe-6270-4d42-bc0e-7caa210e3450.png">