### PR TITLE
Clarify OUnit2 assert_raises.

### DIFF
--- a/src/chapters/data/exceptions.md
+++ b/src/chapters/data/exceptions.md
@@ -238,8 +238,11 @@ expression `e` raises exception `exc`. If so, the OUnit test case succeeds,
 otherwise it fails.
 
 ```{tip}
-A common error is to forget the `(fun () -> ...)` around `e`. If you do, the
-OUnit test case will fail, and you will likely be confused as to why. The reason
-is that, without the extra anonymous function, the exception is raised before
-`assert_raises` ever gets a chance to handle it.
+Note that the second argument of `assert_raises` is a *function* of type `unit
+-> 'a`, sometimes called a "thunk". It may seem strange to write a function with
+this type---the only possible input is `()`---but this is a common pattern in
+functional languages to suspend or delay the evaluation of some program. In this
+case, we want `assert_raises` to evaluate `List.hd []` when it is ready. If we
+evaluated `List.hd []` immediately, `assert_raises` would not be able to check
+if the right exception is raised.
 ```


### PR DESCRIPTION
Previous explanation wasn't quite right: leaving the function out doesn't lead to an exception, it leads to a type error.