### PR TITLE
Remove one case of `expsq`

### DIFF
--- a/src/chapters/correctness/exercises.md
+++ b/src/chapters/correctness/exercises.md
@@ -200,7 +200,6 @@ Prove that `expsq x n = exp x n`, where
 ```ocaml
 let rec expsq x n =
   if n = 0 then 1
-  else if n = 1 then x
   else (if n mod 2 = 0 then 1 else x) * expsq (x * x) (n / 2)
 ```
 


### PR DESCRIPTION
We do not need a separate case for `n = 1`. This will also make it easier for students to prove things. :slightly_smiling_face: