### PR TITLE
Remove unused rec flag in Chapter 8.5

### DIFF
--- a/src/chapters/ds/memoization.md
+++ b/src/chapters/ds/memoization.md
@@ -134,7 +134,7 @@ memoization technique:
 
 ```{code-cell} ocaml
 let fib_memo =
-  let rec fib self n =
+  let fib self n =
     if n < 2 then 1 else self (n - 1) + self (n - 2)
   in
   memo_rec fib


### PR DESCRIPTION
it may be unnecessary to use the `rec` keyword, so removing it