### PR TITLE
Fix function name typo

### DIFF
--- a/src/chapters/ds/promises.md
+++ b/src/chapters/ds/promises.md
@@ -254,10 +254,10 @@ resolved or rejected, and once the state has changed, it will not allow it to be
 changed again. That is, it enforces the "write once" invariant.
 
 ```{code-cell} ocaml
-(** [update p s] changes the state of [p] to be [s].  If [p] and [s]
+(** [write_once p s] changes the state of [p] to be [s].  If [p] and [s]
     are both pending, that has no effect.
     Raises: [Invalid_arg] if the state of [p] is not pending. *)
-let update p s =
+let write_once p s =
   if !p = Pending
   then p := s
   else invalid_arg "cannot write twice"

--- a/src/chapters/ds/promises.md
+++ b/src/chapters/ds/promises.md
@@ -142,7 +142,8 @@ library for promises.
 
 [lwt-github]: https://github.com/ocsigen/lwt
 
-In Lwt, a *promise* is a write-once reference: a value that is permitted to
+In Lwt, a *promise* is a 
+reference: a value that is permitted to
 mutate at most once. When created, it is like an empty box that contains
 nothing. We say that the promise is *pending*. Eventually the promise can be
 *resolved*, which is like putting something inside the box. Instead of being
@@ -253,10 +254,10 @@ resolved or rejected, and once the state has changed, it will not allow it to be
 changed again. In other words, `update` enforces the "write once" invariant.
 
 ```{code-cell} ocaml
-(** [write_once p s] changes the state of [p] to be [s].  If [p] and [s]
+(** [update p s] changes the state of [p] to be [s].  If [p] and [s]
     are both pending, that has no effect.
     Raises: [Invalid_arg] if the state of [p] is not pending. *)
-let write_once p s =
+let update p s =
   if !p = Pending
   then p := s
   else invalid_arg "cannot write twice"

--- a/src/chapters/ds/promises.md
+++ b/src/chapters/ds/promises.md
@@ -248,10 +248,10 @@ using the type system to control whether it's possible to apply certain
 functions (e.g., `state` vs `resolve`) to a promise.
 
 To help implement the rest of the functions, let's start by writing a helper
-function `update : 'a promise -> 'a state -> unit` to update the reference. This
+function `write_once : 'a promise -> 'a state -> unit` to update the reference. This
 function will implement changing the state of the promise from pending to either
 resolved or rejected, and once the state has changed, it will not allow it to be
-changed again. In other words, `update` enforces the "write once" invariant.
+changed again. That is, it enforces the "write once" invariant.
 
 ```{code-cell} ocaml
 (** [update p s] changes the state of [p] to be [s].  If [p] and [s]


### PR DESCRIPTION
The description above describes a function called `update` but the code below uses `write_once`