### PR TITLE
remove unused package during install step

### DIFF
--- a/src/chapters/preface/install.md
+++ b/src/chapters/preface/install.md
@@ -326,7 +326,7 @@ Also, make sure you really did log out of your OS (or reboot).
 Continue by installing the OPAM packages we need:
 
 ```console
-opam install -y utop odoc ounit2 qcheck bisect_ppx menhir ocaml-lsp-server ocamlformat ocamlformat-rpc
+opam install -y utop odoc ounit2 qcheck bisect_ppx menhir ocaml-lsp-server ocamlformat
 ```
 
 Make sure to grab that whole line above when you copy it. You will get some


### PR DESCRIPTION
In the *preface* at the *install* chapter there is a *isntall package* with the following packages:
 
https://github.com/cs3110/textbook/blob/a2d49c53092e0931618185cf03fa2f5f697c26dd/src/chapters/preface/install.md?plain=1#L328C1-L330C4

```
opam install -y utop odoc ounit2 qcheck bisect_ppx menhir ocaml-lsp-server ocamlformat ocamlformat-rpc
```

The following message is being displayed 
```
The `ocamlformat` package ships the RPC mode since version 0.22.4. This package is no longer necessary.
```

This PR removes that unused package.