### PR TITLE
Update "refactor arith"

### DIFF
--- a/src/chapters/modules/exercises.md
+++ b/src/chapters/modules/exercises.md
@@ -432,7 +432,7 @@ response from one phrase will change in a helpful way. Explain why.
 {{ ex4 | replace("%%NAME%%", "refactor arith")}}
 
 Download this file: {{ code_link | replace("%%NAME%%", "algebra.ml")}}. It
-contains two signatures and four structures:
+contains two signatures and six structures:
 
 * `Ring` is signature that describes the algebraic structure called a *[ring]*,
   which is an abstraction of the addition and multiplication operators.

--- a/src/chapters/modules/exercises.md
+++ b/src/chapters/modules/exercises.md
@@ -480,7 +480,7 @@ needed. There isn't necessarily a right answer here, but here's some advice:
   `include` or a functor application.
 
 * The rational structures can both be produced by a single functor that is
-  applied once to `IntField` and once to `FloatField`.
+  applied once to `IntRing` and once to `FloatRing`.
 
 * It's possible to eliminate all duplication of `of_int`, such that it is
   directly defined exactly once, and all structures reuse that definition; and


### PR DESCRIPTION
Two things I noticed for the exercise "refactor arith":

- The file [algebra.ml][1] contains six structures (3 `Ring`s and 3 `Field`s), not four.
- The `Fraction` functor only needs its input to be a `Ring`, not an entire `Field`. (This is also mathematically important, since the [“field of fractions” construction][2] is used to embed a ring into a field.)

[1]: https://cs3110.github.io/textbook/code/algebra.ml
[2]: https://en.wikipedia.org/wiki/Field_of_fractions