### PR TITLE
5.6.3: Expose the exception 'Empty' as part of the module signature.

### DIFF
--- a/src/chapters/modules/functional_data_structures.md
+++ b/src/chapters/modules/functional_data_structures.md
@@ -205,6 +205,7 @@ our stack module:
 :tags: ["hide-output"]
 module type Stack = sig
   type 'a t
+  exception Empty
   val empty : 'a t
   val is_empty : 'a t -> bool
   val push : 'a -> 'a t -> 'a t


### PR DESCRIPTION
I believe that the last example in section 5.6.3 (Options vs Exceptions) should expose the exception `Empty` via the module signature. This is how it was done in all previous examples, and also how it is done in the standard library (e.g., https://v2.ocaml.org/api/type_Stack.html).