### PR TITLE
Update exercises.md to clarify spec of `Fraction.make`

### DIFF
--- a/src/chapters/modules/exercises.md
+++ b/src/chapters/modules/exercises.md
@@ -111,7 +111,8 @@ module type Fraction = sig
   (* A fraction is a rational number p/q, where q != 0. *)
   type t
 
-  (** [make n d] is n/d. Requires d != 0. *)
+  (** [make n d] represents n/d, a fraction with numerator [n] and denominator [d].
+      Requires d != 0. *)
   val make : int -> int -> t
 
   val numerator : t -> int


### PR DESCRIPTION
This PR clarifies a documentation comment in the 3-star exercise "[fraction](https://cs3110.github.io/textbook/chapters/modules/exercises.html)". The change was motivated by a post on the Ed discussion forum of CS3110's fall 2024 offering, where a student took `[make n d] is n/d` to mean that the division indicated by `/` would _go through_, and the resultant integer would be stored. [Here](https://edstem.org/us/courses/62757/discussion/5553416?comment=12877663) is a link to that post.