### PR TITLE
Update Promises to fix function name

### DIFF
--- a/src/chapters/ds/promises.md
+++ b/src/chapters/ds/promises.md
@@ -957,10 +957,10 @@ handlers list to be empty to ensure that the RI holds.
     List.iter (fun f -> f st) handlers
 
   let reject r x =
-    resolve r (Rejected x)
+    fulfill_or_reject r (Rejected x)
 
   let fulfill r x =
-    resolve r (Fulfilled x)
+    fulfill_or_reject r (Fulfilled x)
 ```
 
 Finally, the implementation of `>>=` is the trickiest part. First, if the


### PR DESCRIPTION
The chapter Promises builds up a to an implementation of callbacks. The final sample code is correct, but one of the intermediate examples contains a bug: a helper is named incorrectly in the calling function. This PR fixes that.