### PR TITLE
Extend copyright to 2025

### DIFF
--- a/src/_config.yml
+++ b/src/_config.yml
@@ -3,7 +3,7 @@
 
 title: 'OCaml Programming: Correct + Efficient + Beautiful'
 author: Michael R. Clarkson et al.
-copyright: "2024"
+copyright: "2025"
 logo: op_title.png
 only_build_toc_files: true
 

--- a/src/cover.md
+++ b/src/cover.md
@@ -20,7 +20,7 @@ easy task. The primary compiler and author of this work in its form as a unified
 textbook is Michael R. Clarkson, who as of the Fall 2021 edition was the author
 of about 40% of the words and code tokens.
 
-**Copyright 2021–2024 Michael R. Clarkson.** Released under the <a rel="license"
+**Copyright 2021–2025 Michael R. Clarkson.** Released under the <a rel="license"
 href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons
 Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.
 


### PR DESCRIPTION
This PR extends the copyright of the textbook to the year 2025.