### PR TITLE
docs: Update functions.md call to apply

### DIFF
--- a/src/chapters/basics/functions.md
+++ b/src/chapters/basics/functions.md
@@ -531,7 +531,7 @@ use the following syntax:
 let f ?name:(arg1=8) arg2 = arg1 + arg2
 ```
 
-You can then call a function with or without the argument:
+You can then apply the function with or without the argument:
 
 ```{code-cell} ocaml
 f ~name:2 7


### PR DESCRIPTION
To keep it consistent with OCaml language of:
In OCaml the usual vocabulary is that we “apply” the function rather than “call” it. Source of reference: https://cs3110.github.io/textbook/chapters/basics/toplevel.html

I fixed the typo:
Original Version: 
You can then call a function with or without the argument: Fixed Version: 
You can then apply the function with or without the argument: