### PR TITLE
Remove line about @author tag in assignments

### DIFF
--- a/src/chapters/basics/documentation.md
+++ b/src/chapters/basics/documentation.md
@@ -19,12 +19,7 @@ let rec sum lst = ...
   be rendered in HTML as `typewriter font` rather than the regular font.
 
 Also like Javadoc, OCamldoc supports *documentation tags*, such as `@author`,
-`@deprecated`, `@param`, `@return`, etc. For example, in the first line of most
-programming assignments, we ask you to complete a comment like this:
-
-```ocaml
-(** @author Your Name (your netid) *)
-```
+`@deprecated`, `@param`, `@return`, etc. 
 
 For the full range of possible markup inside a OCamldoc comment, see
 [the OCamldoc manual](https://ocaml.org/manual/ocamldoc.html).


### PR DESCRIPTION
The page about Documentation contains the line:

> For example, in the first line of most programming assignments, we ask you to complete a comment like this:
```ocaml
(** @author Your Name (your netid) *)
```

This PR removes that line for the following reasons:
1. It is no longer true in Cornell's CS 3110. We now ask for an AUTHORS.md file.
2. A reference to "most programming assignments" makes the textbook feel too tied down to Cornell's CS 3110, while in fact the textbook is used by several others.