### PR TITLE
Fix question by providing missing code

### DIFF
--- a/src/chapters/correctness/exercises.md
+++ b/src/chapters/correctness/exercises.md
@@ -274,6 +274,13 @@ let rec size = function
   | Leaf -> 0
   | Node (l, v, r) -> 1 + size l + size r
 ```
+and
+
+```ocaml
+let rec reflect = function
+  | Leaf -> Leaf
+  | Node (l, v, r) -> Node (reflect r, v, reflect l) 
+```
 
 <!--------------------------------------------------------------------------->
 {{ ex4 | replace("%%NAME%%", "fold theorem 2")}}


### PR DESCRIPTION
Chapter 6's exercise "reflect size" was incomplete: it lacked source code for the `reflect` function. This PR adds that code.