### PR TITLE
Add a discussion of `map` in the Promises chapter

### DIFF
--- a/src/chapters/ds/exercises.md
+++ b/src/chapters/ds/exercises.md
@@ -414,7 +414,7 @@ Implement `map` and `filter` for the `'a lazysequence` type provided in the
 section on laziness.
 
 <!--------------------------------------------------------------------------->
-{{ ex1 | replace("%%NAME%%", "map via return")}}
+{{ ex1 | replace("%%NAME%%", "map via bind")}}
 
 Use the finished version of the `Promise` module we developed to also implement the `map` operator. Review the text for a description of the behavior of `map p f`. You may call `bind` in your implementation of `map`. Hint: use `return`.
 

--- a/src/chapters/ds/exercises.md
+++ b/src/chapters/ds/exercises.md
@@ -334,7 +334,7 @@ compute that involves a function that computes $f(k) = \frac{x^k}{k!}$.
 
 Define a function `total : float sequence -> float sequence`, such that
 `total <a; b; c; ...>` is a running total of the input elements, i.e.,
-`<a; a+.b; a+.b+.c; ...>`. 
+`<a; a+.b; a+.b+.c; ...>`.
 
 By using `e_terms` and `total` together, you will be able to compute successive
 approximations of $e^x$ that correspond to finite prefixes of the infinite
@@ -354,7 +354,7 @@ positive. For example,
 Finally, define a function `e : float -> float -> float` such that `e x eps` is
 $e^x$ computed using a finite prefix of the infinite summation above. The
 computation should halt when the absolute difference between successive
-approximations is below `eps`, which must be strictly positive. For 
+approximations is below `eps`, which must be strictly positive. For
 example, `e 1. 0.01` would be `2.71666666666666634`.
 
 <!--------------------------------------------------------------------------->
@@ -412,6 +412,16 @@ should force `lb2` and return its value.
 
 Implement `map` and `filter` for the `'a lazysequence` type provided in the
 section on laziness.
+
+<!--------------------------------------------------------------------------->
+{{ ex1 | replace("%%NAME%%", "map via return")}}
+
+Use the finished version of the `Promise` module we developed to also implement the `map` operator. Review the text for a description of the behavior of `map p f`. You may call `bind` in your implementation of `map`. Hint: use `return`.
+
+<!--------------------------------------------------------------------------->
+{{ ex2 | replace("%%NAME%%", "map anew")}}
+
+Use the finished version of the `Promise` module we developed to also implement the `map` operator. Review the text for a description of the behavior of `map p f`. You may use the code we developed for `bind` as a template, but you may not call `bind` in your implementation of `map`.
 
 <!--------------------------------------------------------------------------->
 {{ ex2 | replace("%%NAME%%", "promise and resolve")}}

--- a/src/chapters/ds/promises.md
+++ b/src/chapters/ds/promises.md
@@ -142,7 +142,7 @@ library for promises.
 
 [lwt-github]: https://github.com/ocsigen/lwt
 
-In Lwt, a *promise* is a 
+In Lwt, a *promise* is a
 reference: a value that is permitted to
 mutate at most once. When created, it is like an empty box that contains
 nothing. We say that the promise is *pending*. Eventually the promise can be
@@ -815,6 +815,15 @@ sequentially compose callbacks: first one callback is run, then another, then
 another, and so forth. There are other functions in the library for composition
 of many callbacks as a set. For example,
 
+* `Lwt.map : 'a Lwt.t -> ('a -> 'b) -> 'b Lwt.t` is a lot like `Lwt.bind`,
+  but its callback function immediately returns a *value* of type `'b`, not the
+  *promise* of a value of type `'b`. `Lwt.map p f` returns a promise that is
+  pending until `p` is resolved. If `p` is resolved via rejection, the callback is
+  never called and the pending promise is rejected with the same exception. If
+  `p` is resolved via fulfilment (say with value `v`), then the pending promise
+  is resolved with `f v`. Note that `f` may itself raise an exception, in which
+  case the pending promise is rejected with that exception.
+
 * `Lwt.join : unit Lwt.t list -> unit Lwt.t` enables waiting upon multiple
   promises. `Lwt.join ps` returns a promise that is pending until all the
   promises in `ps` become resolved. You might register a callback on the return
@@ -983,7 +992,7 @@ that is rejected with the same exception:
     | Rejected exc -> {state = Rejected exc; handlers = []}
 ```
 
-Third, if the promise is pending, we need to do more work. 
+Third, if the promise is pending, we need to do more work.
 The `bind` function needs to return a new promise. That promise will become
 fulfilled when (or if) the callback completes running, sometime in the future.
 Its contents will be whatever contents are contained within the promise that the


### PR DESCRIPTION
This PR closes #212 by adding a paragraph about `map` and two exercises encouraging students to try implementing `map`.