### PR TITLE
Improvements in Promises chapter

### DIFF
--- a/src/_toc.yml
+++ b/src/_toc.yml
@@ -92,6 +92,7 @@ parts:
       - file: chapters/conc/impl_promises.md
       - file: chapters/conc/io_promises.md
       - file: chapters/conc/callbacks.md
+      - file: chapters/conc/impl_callbacks.md
       - file: chapters/conc/full_promises_impl.md
       - file: chapters/conc/monads.md
       - file: chapters/conc/summary.md

--- a/src/chapters/conc/full_promises_impl.md
+++ b/src/chapters/conc/full_promises_impl.md
@@ -94,7 +94,7 @@ module Promise : PROMISE = struct
   let state p = p.state
 
   (** Requires: [st] may not be [Pending]. *)
-  let fulfill_or_reject (r : 'a resolver) (st : 'a state) =
+  let resolve (r : 'a resolver) (st : 'a state) =
     assert (st <> Pending);
     let handlers = r.handlers in
     r.handlers <- [];
@@ -102,12 +102,12 @@ module Promise : PROMISE = struct
     List.iter (fun f -> f st) handlers
 
   let reject r x =
-    fulfill_or_reject r (Rejected x)
+    resolve r (Rejected x)
 
   let fulfill r x =
-    fulfill_or_reject r (Fulfilled x)
+    resolve r (Fulfilled x)
 
-  let handler (resolver : 'a resolver) : 'a handler
+  let copying_handler (resolver : 'a resolver) : 'a handler
     = function
       | Pending -> failwith "handler RI violated"
       | Rejected exc -> reject resolver exc
@@ -125,7 +125,7 @@ module Promise : PROMISE = struct
           match promise.state with
           | Fulfilled y -> fulfill resolver y
           | Rejected exc -> reject resolver exc
-          | Pending -> enqueue (handler resolver) promise
+          | Pending -> enqueue (copying_handler resolver) promise
         with exc -> reject resolver exc
 
   let ( >>= )

--- a/src/chapters/conc/full_promises_impl.md
+++ b/src/chapters/conc/full_promises_impl.md
@@ -115,18 +115,19 @@ module Promise : PROMISE = struct
 
   let handler_of_callback
       (callback : 'a -> 'b promise)
-      (resolver : 'b resolver) : 'a handler
-    = function
-      | Pending -> failwith "handler RI violated"
-      | Rejected exc -> reject resolver exc
-      | Fulfilled x ->
-        try
-          let promise = callback x in
-          match promise.state with
-          | Fulfilled y -> fulfill resolver y
-          | Rejected exc -> reject resolver exc
-          | Pending -> enqueue (copying_handler resolver) promise
-        with exc -> reject resolver exc
+      (resolver : 'b resolver) : 'a handler =
+      fun (state : 'a state) ->
+      match state with
+        | Pending -> failwith "handler RI violated"
+        | Rejected exc -> reject resolver exc
+        | Fulfilled x ->
+          try
+            let promise = callback x in
+            match promise.state with
+            | Fulfilled y -> fulfill resolver y
+            | Rejected exc -> reject resolver exc
+            | Pending -> enqueue (copying_handler resolver) promise
+          with exc -> reject resolver exc
 
   let ( >>= )
       (input_promise : 'a promise)

--- a/src/chapters/conc/impl_promises.md
+++ b/src/chapters/conc/impl_promises.md
@@ -69,7 +69,7 @@ It will simply be the same as a promise.
 type 'a resolver = 'a promise
 ```
 
-So internally, the two types are exactly the same. But externally no client of
+So internally, the two types are exactly the same. But externally, no client of
 the `Promise` module will be able to distinguish them. In other words, we're
 using the type system to control whether it's possible to apply certain
 functions (e.g., `state` vs `fulfill`) to a promise.
@@ -95,7 +95,7 @@ Using that helper, we can implement the `make` function:
 ```{code-cell} ocaml
 let make () =
   let p = ref Pending in
-  p, p
+  (p, p)
 ```
 
 The remaining functions in the interface are trivial to implement.


### PR DESCRIPTION
This PR closes #214 

- It adds a little more English exposition, and takes care to remind the reader than a promise may not be fulfilled.
- It uses better names for functions when developing the "final" code which features callbacks.
- It adds a step-by-step explanation of the helper function `resolve`.
- It explains the mechanism of the tricky `handler_of_callback` function, in particular by explicitly crafting an anonymous function that takes a state as its input. This is in favor of using the `function` keyword, which was a bit too cute.
- Important! ea6042a488f6fbf08317fd7f2941edada9bef0b4 had fat-fingered away a whole section (about implementing callbacks) by omitting it from the TOC; this PR adds that back.

Issue 214 proposed explaining in the English text that some partial application was going on. I believe the changes I actually made don't require that explanation any more.
