### PR TITLE
Small typo in Promises chapter

### DIFF
--- a/src/chapters/conc/impl_callbacks.md
+++ b/src/chapters/conc/impl_callbacks.md
@@ -178,8 +178,8 @@ return:
     | Fulfilled x -> callback x
 ```
 
-Second, if the promise is already rejected, then we quickly craft a new promise
-that is also rejected with the same exception as has no handlers waiting on it.
+Second, if the promise is already rejected with some exception, we craft a trivial new promise
+that is also rejected with the same exception.
 We return that new promise to the user immediately:
 ```ocaml
     | Rejected exc -> {state = Rejected exc; handlers = []}


### PR DESCRIPTION
Sorry, I introduced a typo in #217: "as has no handlers waiting on it" instead of "_and_ has...". This PR simplifies the line and massages away the typo.