### PR TITLE
Update link to syntax of Dune files

### DIFF
--- a/src/chapters/basics/compiling.md
+++ b/src/chapters/basics/compiling.md
@@ -97,7 +97,7 @@ LISP called *s-expressions*, in which parentheses are used to show nested data
 that form a tree, much like HTML tags do. The syntax of Dune files is documented
 in the [Dune manual][dune-man].
 
-[dune-man]: https://dune.readthedocs.io/en/stable/dune-files.html
+[dune-man]: https://dune.readthedocs.io/en/stable/reference/dune/index.html
 
 ### Creating a Dune Project Manually
 


### PR DESCRIPTION
The `dune-files` page gives 404 error now, as it has been split into smaller pages, see https://github.com/ocaml/dune/commit/a2ca7674319adc003727686d64ca2a0c9749f3d4.

I've checked that this is the only link to dune.readthedocs.io in the textbook.