### PR TITLE
Correct typos

### DIFF
--- a/src/chapters/basics/expressions.md
+++ b/src/chapters/basics/expressions.md
@@ -94,7 +94,7 @@ is a `float`; if you write it as `3`, it is instead an `int`:
 3
 ```
 
-OCaml deliberately does not support operator overloading, Arithmetic operations
+OCaml deliberately does not support operator overloading. Arithmetic operations
 on floats are written with a dot after them. For example, floating-point
 multiplication is written `*.` not `*`:
 

--- a/src/chapters/conc/impl_callbacks.md
+++ b/src/chapters/conc/impl_callbacks.md
@@ -229,7 +229,7 @@ later becomes resolved:
 
 All that's left is to implement that helper function to create handlers out of
 callbacks. Recall that a handler's type is itself a *function type*,
-`'a state -> unit`. This is why our helper function's output is actally an
+`'a state -> unit`. This is why our helper function's output is actually an
 anonymous function. That anonymous function takes a state as its input:
 
 ```ocaml
@@ -255,7 +255,7 @@ promise returned by bind to also be rejected.
       | Rejected exc -> reject resolver exc
 ```
 
-But if the state is fulfiled, then the callback registered with the promise
+But if the state is fulfilled, then the callback registered with the promise
 can&mdash;at last!&mdash;be run on the contents of the fulfilled promise. If the callback executes successfully it produces a new promise, but recall that the callback
 may itself raise an exception.
 

--- a/src/chapters/ds/parrays.md
+++ b/src/chapters/ds/parrays.md
@@ -191,7 +191,7 @@ end
 
 ## Rebasing Version-Tree Arrays
 
-With version trees, we achieved constant-time `set` operations for a persistent array, but `get` operations were no longer constant time — they were $O(k)$ where $k$ was the number of `set` operations that had been perfromed. Is there a way to make both operations constant time while still being persistent? The answer is: almost! 
+With version trees, we achieved constant-time `set` operations for a persistent array, but `get` operations were no longer constant time — they were $O(k)$ where $k$ was the number of `set` operations that had been performed. Is there a way to make both operations constant time while still being persistent? The answer is: almost! 
 
 Right now, the original version of the array as stored in the `Base` node is _primary_ and always has constant-time access with `get`. We are going to introduce a new _rebasing_ operation that can make any other version of the array become primary. Then that version will have constant-time access with `get`, even though other versions will still be $O(k)$. When a version $v$ of an array is accessed (either with `length` or `set`), we will mutate the version tree to make $v$ primary. That means changing the `Base` node to store the contents according to $v$, and adjusting `Diff` nodes as needed to compensate for that change in the base.
 

--- a/src/chapters/modules/functional_data_structures.md
+++ b/src/chapters/modules/functional_data_structures.md
@@ -268,7 +268,7 @@ module type Queue = sig
   val front : 'a t -> 'a
 
   (** [dequeue q] is the queue containing all the elements of [q] except the
-      front of [q]. Raises [Empty] is [q] is empty. *)
+      front of [q]. Raises [Empty] if [q] is empty. *)
   val dequeue : 'a t -> 'a t
 
   (** [size q] is the number of elements in [q]. *)


### PR DESCRIPTION
Spelling mistakes are found by using the [`typos`](https://github.com/crate-ci/typos) tool.