### PR TITLE
Bump Dune to v3.21, part 2

### DIFF
--- a/src/chapters/data/ounit.md
+++ b/src/chapters/data/ounit.md
@@ -70,7 +70,7 @@ file and put this in it:
 And create a `dune-project` file as usual:
 
 ```text
-(lang dune 3.4)
+(lang dune 3.21)
 ```
 
 Now build the test suite:


### PR DESCRIPTION
Continuation of 71734a0 (Bump Dune to v3.21, 2026-01-26).

I searched for `3.4` in this repo and spot another occurrence.