### PR TITLE
Change hash table size in memoization example

### DIFF
--- a/src/chapters/ds/memoization.md
+++ b/src/chapters/ds/memoization.md
@@ -103,7 +103,7 @@ convert to a single argument function).
 
 ```{code-cell} ocaml
 let memo f =
-  let h = Hashtbl.create 11 in
+  let h = Hashtbl.create 16 in
   fun x ->
     try Hashtbl.find h x
     with Not_found ->


### PR DESCRIPTION
`16` is a much more standard magic number than `11`, and anyway the other example just below uses `16`. Making this minor change gives the two examples a smaller diff, which lets students focus on the right thing.